### PR TITLE
Add opam-pin on ZArith 1.11

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -75,13 +75,13 @@ ensure_setup () {
         fi
     fi
     eval $(opam env)
-    opam install --deps-only \
-         local-vendor/tezos/src/lib_contract_metadata/tezos-contract-metadata.opam
     opam pin add -n digestif 0.9.0
     opam pin add -n ocamlformat 0.15.0
     opam pin add -n tyxml 4.4.0
     opam pin add -n zarith 1.11 # zarith_stubs_js fails with 1.12
     # see https://github.com/janestreet/zarith_stubs_js/pull/8
+    opam install --deps-only \
+         local-vendor/tezos/src/lib_contract_metadata/tezos-contract-metadata.opam
     opam install -y base fmt uri cmdliner ezjsonm \
          ocamlformat uri merlin ppx_deriving angstrom \
          ppx_inline_test lwt-canceler.0.3 zarith_stubs_js \

--- a/please.sh
+++ b/please.sh
@@ -80,6 +80,8 @@ ensure_setup () {
     opam pin add -n digestif 0.9.0
     opam pin add -n ocamlformat 0.15.0
     opam pin add -n tyxml 4.4.0
+    opam pin add -n zarith 1.11 # zarith_stubs_js fails with 1.12
+    # see https://github.com/janestreet/zarith_stubs_js/pull/8
     opam install -y base fmt uri cmdliner ezjsonm \
          ocamlformat uri merlin ppx_deriving angstrom \
          ppx_inline_test lwt-canceler.0.3 zarith_stubs_js \


### PR DESCRIPTION
ZArith 1.12 conflicts with `zarith_stubs_js`.

See also [janestreet/zarith_stubs_js#8](https://github.com/janestreet/zarith_stubs_js/pull/8)